### PR TITLE
Update NetSdrClient.cs

### DIFF
--- a/NetSdrClientApp/NetSdrClient.cs
+++ b/NetSdrClientApp/NetSdrClient.cs
@@ -14,8 +14,9 @@ namespace NetSdrClientApp
 {
     public class NetSdrClient
     {
-        private ITcpClient _tcpClient;
-        private IUdpClient _udpClient;
+        private readonly ITcpClient _tcpClient;
+        private readonly IUdpClient _udpClient;
+
 
         public bool IQStarted { get; set; }
 


### PR DESCRIPTION

<img width="1221" height="874" alt="image" src="https://github.com/user-attachments/assets/49efcd37-d47e-431d-a5bd-9fa1b4b0a16e" />

Рефакторинг: додано readonly для _tcpClient та _udpClient з метою підвищення безпечності та підтримуваності коду
У цьому Pull Request виправлено зауваження SonarCloud (S2933), що стосується змінних класу NetSdrClient, які могли бути позначені як readonly.
Поля _tcpClient та _udpClient ініціалізуються лише в конструкторі та більше не змінюються протягом життєвого циклу об’єкта.
Для покращення зрозумілості та безпеки коду вони були оголошені як readonly.
<img width="1083" height="116" alt="image" src="https://github.com/user-attachments/assets/7e1833f5-0ab9-421a-a209-122646b19d69" />
Поля _tcpClient та _udpClient позначені як readonly.

Логіка роботи класу не змінена.

Виправлено попередження SonarCloud (csharpsquid:S2933).

Проведено перевірку на коректну роботу після змін.