### PR TITLE
Update NetSdrClient.cs

### DIFF
--- a/NetSdrClientApp/NetSdrClient.cs
+++ b/NetSdrClientApp/NetSdrClient.cs
@@ -14,8 +14,9 @@ namespace NetSdrClientApp
 {
     public class NetSdrClient
     {
-        private ITcpClient _tcpClient;
-        private IUdpClient _udpClient;
+      private readonly ITcpClient _tcpClient;
+      private readonly IUdpClient _udpClient;
+
 
         public bool IQStarted { get; set; }
 


### PR DESCRIPTION

<img width="1919" height="1025" alt="image" src="https://github.com/user-attachments/assets/5ff081dd-98e9-46d7-9a88-62d22f8fa18d" />

Рефакторинг: додано readonly для _tcpClient та _udpClient з метою підвищення безпечності та підтримуваності коду
У цьому Pull Request виправлено зауваження SonarCloud (S2933), що стосується змінних класу NetSdrClient, які могли бути позначені як readonly.
Поля _tcpClient та _udpClient ініціалізуються лише в конструкторі та більше не змінюються протягом життєвого циклу об’єкта.
Для покращення зрозумілості та безпеки коду вони були оголошені як readonly.
<img width="980" height="88" alt="image" src="https://github.com/user-attachments/assets/8b3344bd-d1a3-4afb-81c7-e3fdc8b487fc" />


