### PR TITLE
Update NetSdrClient.cs

### DIFF
--- a/NetSdrClientApp/NetSdrClient.cs
+++ b/NetSdrClientApp/NetSdrClient.cs
@@ -66,7 +66,8 @@ namespace NetSdrClientApp
                 return;
             }
 
-;           var iqDataMode = (byte)0x80;
+            var iqDataMode = (byte)0x80;
+            
             var start = (byte)0x02;
             var fifo16bitCaptureMode = (byte)0x01;
             var n = (byte)1;


### PR DESCRIPTION

<img width="1915" height="1030" alt="image" src="https://github.com/user-attachments/assets/f18d5cee-09ab-4f6b-9844-d237b64559af" />

У методі StartIQAsync класу NetSdrClient виявлено порожній оператор (empty statement) - зайву крапку з комою на початку рядка 67:
SonarQube Issue Details:

Правило: csharpsquid:S1116 - "Empty statements should be removed"
Серйозність: Minor (Low)
Тип: Code Smell
Категорія впливу: Maintainability (Підтримуваність)
Це призводило до попередження SonarQube csharpsquid:S1116: "Empty statements should be removed" (Порожні оператори повинні бути видалені).
Зміни в коді:

Видалено порожній оператор

Вилучено зайву крапку з комою на початку рядка 67


Виправлено форматування

Нормалізовано відступи відповідно до стилю коду проєкту
Привели до єдиного стилю з іншими методами класу
<img width="951" height="135" alt="image" src="https://github.com/user-attachments/assets/7a3305a1-b750-47b3-8f4a-a1081a82bec2" />
