### PR TITLE
Update NetSdrClient.cs

### DIFF
--- a/NetSdrClientApp/NetSdrClient.cs
+++ b/NetSdrClientApp/NetSdrClient.cs
@@ -117,7 +117,7 @@ namespace NetSdrClientApp
 
         private void _udpClient_MessageReceived(object? sender, byte[] e)
         {
-            NetSdrMessageHelper.TranslateMessage(e, out MsgTypes type, out ControlItemCodes code, out ushort sequenceNum, out byte[] body);
+            NetSdrMessageHelper.TranslateMessage(e, out _, out ControlItemCodes code, out ushort sequenceNum, out byte[] body);
             var samples = NetSdrMessageHelper.GetSamples(16, body);
 
             Console.WriteLine($"Samples recieved: " + body.Select(b => Convert.ToString(b, toBase: 16)).Aggregate((l, r) => $"{l} {r}"));


### PR DESCRIPTION
Видалено непотрібну локальну змінну type у методі _udpClient_MessageReceived (S1481)

<img width="1919" height="1024" alt="image" src="https://github.com/user-attachments/assets/57a88ed1-ee64-4256-a0d4-2471429638c9" />

Номер багу / Code Smell:

S1481 – Unused local variable

Рівень впливу:

Minor / Low – покращує підтримуваність коду, не змінюючи логіку.

Файл / Рядок:

NetSdrClient.cs / лінія 119

Що було змінено:
<img width="1317" height="135" alt="image" src="https://github.com/user-attachments/assets/b963e7b4-f34d-43b4-9ee6-6f939dd56834" />
Змінна type ніколи не використовувалась.
Код працює так само, як і раніше.

Видалено зайву локальну змінну → покращено читабельність і підтримуваність.

SonarCloud більше не показує code smell S1481.
